### PR TITLE
Support async/await

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ $ npm i -D eslint-plugin-should-promised
 
 ## Rules
 
-### Require promise assertions to return (return-promise)
+### Require promise assertions to return or await (return-promise)
 
-This rule is intended to be used with the [should-promised](https://www.npmjs.com/package/should-promised) plugin for the [should](https://www.npmjs.com/package/should) assertion library.
+This rule is intended to be used with the [should](https://www.npmjs.com/package/should) assertion library.
 
-When testing an async function by returning a promise to [mocha](https://www.npmjs.com/package/mocha) it is important to remember to actually return the promise. Forgetting to return will not cause the test case to fail.
+When testing an async function by returning a promise to [mocha](https://www.npmjs.com/package/mocha) it is important to remember to actually return the promise. Forgetting to return will cause the test case to pass even if the promise is eventually rejected.
 
-This rule will point out when a [should-promised](https://www.npmjs.com/package/should-promised) assertion is made without returning.
+This rule will point out when a [should](https://www.npmjs.com/package/should) assertion is made without returning.
 
 #### Rule Details
 
@@ -47,32 +47,42 @@ This rule looks for any of the properties `Promise`, `fulfilled`, `fulfilledWith
 The following patterns are considered warnings:
 
 ```js
-describe('forgot to return the promise', function() {
-  it('warn when not returning the promise from should.be.fulfilled', function() {
-    thing.fn().should.be.fulfilled();
+describe('forgetting to return the promise', () => {
+
+  it('should report when not returning the promise from should.be.fulfilled', () => {
+    promiseFn().should.be.fulfilled();
   });
 
-  it('warn when not returning the promise from should.eventually', function() {
-    thing.fn().should.eventually.eql(1);
+  it('should report when not returning the promise from should.eventually', () => {
+    promiseFn().should.eventually.eql(1);
   });
+
 });
 ```
 
 These patterns would not be considered warnings:
 
 ```js
-describe('forgot to return the promise', function() {
-  it('warn when not returning the promise from should.be.fulfilled', function() {
-    return thing.fn().should.be.fulfilled();
+describe('returning the promise', () => {
+
+  it('should not report when returning the promise from should.be.fulfilled', () => {
+    return promiseFn().should.be.fulfilled();
   });
 
-  it('warn when not returning the promise from should.eventually', function() {
-    return thing.fn().should.eventually.eql(1);
+  it('should allow implicit return in a single expression arrow function', () =>
+    promiseFn().should.be.fulfilled());
+
+  it('should not report when using async/await', async () => {
+    await promiseFn().should.eventually.eql(expected_value);
   });
+
+  it('should not report when using a generator function', function * () {
+    yield generatorFn().should.eventually.eql(expected_value);
+  });
+
 });
 ```
 
 #### Further Reading
 
 - The [should](https://www.npmjs.com/package/should) assertion library
-- The [should-promised](https://www.npmjs.com/package/should-promised) plugin

--- a/lib/rules/return-promise.js
+++ b/lib/rules/return-promise.js
@@ -19,7 +19,7 @@ function ancestorReturns(parents) {
   for (var i = parents.length - 1; i >= 0; i--) {
     var parent = parents[i];
     var type = parent.type;
-    if (type === 'ReturnStatement') {
+    if (type === 'ReturnStatement' || type === 'YieldExpression') {
       return true;
     }
     if (type === 'ArrowFunctionExpression' && parent.body.type === 'CallExpression') {
@@ -44,7 +44,7 @@ module.exports = function(context) {
         return;
       }
 
-      context.report(node.property, 'Promise assertion must return.');
+      context.report(node.property, 'Promise assertion must return or await.');
     }
   };
 };

--- a/lib/rules/return-promise.js
+++ b/lib/rules/return-promise.js
@@ -16,12 +16,13 @@ function isPromiseAssertionProperty(property) {
 }
 
 function ancestorReturns(parents) {
-  var i = parents.length - 1,
-      type;
-
-  for (; i >= 0; i--) {
-    type = parents[i].type;
+  for (var i = parents.length - 1; i >= 0; i--) {
+    var parent = parents[i];
+    var type = parent.type;
     if (type === 'ReturnStatement') {
+      return true;
+    }
+    if (type === 'ArrowFunctionExpression' && parent.body.type === 'CallExpression') {
       return true;
     }
     if (type === 'FunctionExpression') {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eslint": ">=0.8.0"
   },
   "devDependencies": {
+    "babel-eslint": "4.1.7",
     "coveralls": "2.11.6",
     "eslint": "1.10.3",
     "is-my-json-valid": "2.12.4",

--- a/test/rules/return-promise.js
+++ b/test/rules/return-promise.js
@@ -3,7 +3,7 @@
 var RuleTester = require('eslint').RuleTester;
 var rule = require('../../lib/rules/return-promise.js');
 var tester = new RuleTester();
-var expectedErrorMessage = 'Promise assertion must return.';
+var expectedErrorMessage = 'Promise assertion must return or await.';
 
 
 tester.run('return-promise', rule, {
@@ -26,6 +26,9 @@ tester.run('return-promise', rule, {
     'var test = function() { return fn().then(function(){}).should.be.fulfilled(); }',
     { code: 'var test = () => { return fn().should.be.fulfilled(); }', ecmaFeatures: { arrowFunctions: true } },
     { code: 'var test = () => fn().should.be.fulfilled();', ecmaFeatures: { arrowFunctions: true } },
+    { code: 'test(function * () { yield fn().should.be.fulfilled(); });', ecmaFeatures: { generators: true } },
+    { code: 'test(async function() { await fn().should.be.rejected(); });', parser: 'babel-eslint' },
+    { code: 'test(async () => { await fn().should.be.rejected(); });', parser: 'babel-eslint' },
   ],
 
   invalid: [
@@ -93,6 +96,16 @@ tester.run('return-promise', rule, {
       code: 'var test = () => { fn().should.be.fulfilled(); }',
       errors: [{ message: expectedErrorMessage, column: 35, line: 1 }],
       ecmaFeatures: { arrowFunctions: true }
+    },
+    {
+      code: 'test(async function() { fn().should.be.rejected(); });',
+      errors: [{ message: expectedErrorMessage, column: 40, line: 1 }],
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'test(async () => { fn().should.be.rejected(); });',
+      errors: [{ message: expectedErrorMessage, column: 35, line: 1 }],
+      parser: 'babel-eslint',
     },
   ],
 

--- a/test/rules/return-promise.js
+++ b/test/rules/return-promise.js
@@ -24,6 +24,8 @@ tester.run('return-promise', rule, {
     'var test = function() { return fn().should.eventually.eql(1); }',
     'var test = function() { return fn().should["eventually"].eql(1); }',
     'var test = function() { return fn().then(function(){}).should.be.fulfilled(); }',
+    { code: 'var test = () => { return fn().should.be.fulfilled(); }', ecmaFeatures: { arrowFunctions: true } },
+    { code: 'var test = () => fn().should.be.fulfilled();', ecmaFeatures: { arrowFunctions: true } },
   ],
 
   invalid: [
@@ -86,7 +88,12 @@ tester.run('return-promise', rule, {
     {
       code: 'fn().should.be.fulfilled();',
       errors: [{ message: expectedErrorMessage, column: 16, line: 1 }]
-    }
-  ]
+    },
+    {
+      code: 'var test = () => { fn().should.be.fulfilled(); }',
+      errors: [{ message: expectedErrorMessage, column: 35, line: 1 }],
+      ecmaFeatures: { arrowFunctions: true }
+    },
+  ],
 
 });


### PR DESCRIPTION
The `return-promise` rule will not report implicit returns in single expression arrow functions or yielded promises in generator or async functions.
